### PR TITLE
Fix `direnv`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,0 @@
-export N_PREFIX="$HOME/.n"
-PATH_add "$N_PREFIX/bin"
-npx n auto


### PR DESCRIPTION
I set up `direnv` a while back to run setup scripts for this, looks like the node version in the `engines` block was removed breaking it:

```
direnv: loading $JAXBOARDS_DIR/.envrc
       found : $JAXBOARDS_DIR/package.json
        read :

  Error: did not find supported version of node in 'engines' field of package.json

direnv: export +N_PREFIX ~PATH
```

also now I don't know what node version we support! So we should add this back.

https://docs.npmjs.com/cli/v11/configuring-npm/package-json#engines

also committed package-lock.json- not sure why we weren't committing that- that seems bad?