### PR TITLE
Change default dbVersion to 5

### DIFF
--- a/Jax/Database/Utils.php
+++ b/Jax/Database/Utils.php
@@ -369,7 +369,7 @@ final readonly class Utils implements Adapter
         $stats->most_members = 1;
         $stats->most_members_day = 1;
         $stats->last_register = 1;
-        $stats->dbVersion = 4;
+        $stats->dbVersion = 5;
         $stats->insert();
 
         $topic = new Topic();


### PR DESCRIPTION
Not sure if this is the right fix for #200, not sure exactly how the install works- didn't see anything for the openGraphMetadata field in there so maybe if I installed a fresh version it'd have all the migrations ran but still have v4 set