### PR TITLE
Fix extraneous line break in Users Online div

### DIFF
--- a/public/Service/Themes/Default/views/idx/stats.html.twig
+++ b/public/Service/Themes/Default/views/idx/stats.html.twig
@@ -9,8 +9,8 @@
         <div class="content_top">
         </div>
         <div class="content">
-            {{ usersOnlineCount }} User{% if usersOnlineCount > 1 %}s{% endif %} Online:
             <div id="statusers">
+                {{ usersOnlineCount }} User{% if usersOnlineCount > 1 %}s{% endif %} Online:
                 {%- for user in usersOnline -%}
                     {%- if user.isBot -%}
                         <a


### PR DESCRIPTION
The "x Users Online" text was outside the div, causing an extra line break to appear after the colon. Now it's structured the same way as the "x Users Online Today" div.